### PR TITLE
custom subdomain name: timeline-report

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -24,6 +24,7 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
+        sub-domain: "timeline-report-${{ github.ref_name }}"
         domain_name: bitovi-jira.com
         app_port: 3000
 

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -24,7 +24,7 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub-domain: "timeline-report-${{ github.ref_name }}"
+        sub_domain: "timeline-report-${{ github.ref_name }}"
         domain_name: bitovi-jira.com
         app_port: 3000
 

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -4,13 +4,17 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   EC2-Deploy:
     # if the branch name of the PR does not contain 'skip-deploy'
     if: "!contains(github.head_ref, 'skip-deploy')"
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name }}
+      name: "PR-${{ github.event.pull_request.number }}"
       url: ${{ steps.deploy.outputs.vm_url }}
     steps:
     - id: deploy
@@ -24,7 +28,7 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub_domain: "timeline-report-${{ github.ref_name }}"
+        sub_domain: "timeline-report-PR-${{ github.event.pull_request.number }}"
         domain_name: bitovi-jira.com
         app_port: 3000
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,8 +22,10 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
+        sub_domain: timeline-report
         domain_name: bitovi-jira.com
         app_port: 3000
+
     - if: ${{ steps.deploy.outputs.vm_url != '' }}
       name: Print result created
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   EC2-Deploy:
     runs-on: ubuntu-latest
@@ -31,6 +35,7 @@ jobs:
       run: |
         echo "## VM Created! :rocket:" >> $GITHUB_STEP_SUMMARY
         echo " ${{ steps.deploy.outputs.vm_url }}" >> $GITHUB_STEP_SUMMARY
+
     - if: ${{ steps.deploy.outputs.vm_url == '' }}
       name: Print result destroyed
       run: |

--- a/.github/workflows/destroy-pr.yaml
+++ b/.github/workflows/destroy-pr.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [ closed ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   destroy:
     # if the branch name of the PR does not contain 'skip-deploy'
@@ -31,14 +35,12 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        domain_name: bitovi-jira.com
-        app_port: 3000
-
     - if: ${{ steps.deploy.outputs.vm_url != '' }}
       name: Print result created
       run: |
         echo "## VM Created! :rocket:" >> $GITHUB_STEP_SUMMARY
         echo " ${{ steps.deploy.outputs.vm_url }}" >> $GITHUB_STEP_SUMMARY
+  
     - if: ${{ steps.deploy.outputs.vm_url == '' }}
       name: Print result destroyed
       run: |


### PR DESCRIPTION
Per: https://bitovi.slack.com/archives/C0452J8G4DD/p1683771854073849

Changes are all to the `.github/workflows` files:

- added `timeline-report` sub_domain param.
  --> The main domain will be `https://timeline-report.bitovi-jira.com/`
- Enhanced the environment naming so they are called `PR-<number>` instead of `<number>/merge`.
  --> PR environments now look like: `https://auto-scheduler-pr-18.bitovi-jira.com/`
- Added concurrency block to all workflows - new runs of a workflow will kill active earlier ones.

Pushing this to main should result in the app being re-deployed to`timeline-report.bitovi-jira.com`

@justinbmeyer: The `CALLBACK_URL` will likely have to be changed in the Jira App configuration.