### PR TITLE
fixing bug with missing previous time

### DIFF
--- a/public/steerco-timeline.js
+++ b/public/steerco-timeline.js
@@ -419,7 +419,7 @@ class SteercoTimeline extends StacheElement {
 		wasReleaseDate(release) {
 
 				const current = release.due;
-				const was = release.lastPeriod.due;
+				const was = release.lastPeriod && release.lastPeriod.due;
 				
 				if (current - DAY_IN_MS > was) {
 						return " (" + this.prettyDate(was) + ")";


### PR DESCRIPTION
if there was no previous time to compare against, the report was breaking