### PR TITLE
Pin timezone to UTC in vitest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globalSetup: "./vitest-global.ts",
+  },
+});

--- a/vitest-global.ts
+++ b/vitest-global.ts
@@ -1,0 +1,3 @@
+export const setup = () => {
+  process.env.TZ = "UTC";
+};


### PR DESCRIPTION
For dates to be more deterministic inside the tests, I am pinning the timezone to be UTC inside the tests.