### PR TITLE
Small fixes in playbooks

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -65,6 +65,8 @@ jobs:
           aws_r53_domain_name: bitovi-jira.com
           aws_elb_app_port: 3000
 
+          docker_full_cleanup: true
+
           aws_ec2_instance_type: t3.small
           aws_ec2_instance_root_vol_size: 30
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,6 +67,8 @@ jobs:
           aws_r53_domain_name: bitovi-jira.com
           aws_elb_app_port: 3000
 
+          docker_full_cleanup: true
+
           aws_ec2_instance_type: t3.small
           aws_ec2_instance_root_vol_size: 16
 

--- a/.github/workflows/destroy-main-manual.yaml
+++ b/.github/workflows/destroy-main-manual.yaml
@@ -23,13 +23,15 @@ jobs:
         aws_default_region: us-east-1
 
         tf_state_bucket_destroy: true
-        #tf_stack_destroy: true
+        tf_stack_destroy: true
 
         aws_r53_enable: true
         aws_r53_sub_domain_name: timeline-report-staging
         aws_r53_domain_name: bitovi-jira.com
         aws_elb_app_port: 3000
-        
+
+        docker_full_cleanup: true
+
         aws_ec2_instance_type: t3.small
         aws_ec2_instance_root_vol_size: 16
 

--- a/.github/workflows/destroy-manual.yaml
+++ b/.github/workflows/destroy-manual.yaml
@@ -32,9 +32,9 @@ jobs:
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_JIRA_INTEGRATIONS}}
         aws_default_region: us-east-1
 
-        stack_destroy: "true"
         aws_resource_identifier: ${{ github.event.inputs.aws_resource_identifier }}
         tf_state_bucket: ${{ github.event.inputs.tf_state_bucket }}
+        tf_stack_destroy: true
         tf_state_bucket_destroy: ${{ github.event.inputs.tf_state_bucket_destroy }}
 
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file


### PR DESCRIPTION
Added the docker_full_cleanup option. 
Will ensure that everything in docker is fresh and clean with each run.

Will run docker-compose down and docker system prune --all --force --volumes after. Docker volumes will be destroyed.
More details [here](https://github.com/bitovi/github-actions-deploy-docker-to-ec2?tab=readme-ov-file#docker-inputs)