### PR TITLE
fixes TR-160

### DIFF
--- a/public/select-issue-type/select-issue-type.js
+++ b/public/select-issue-type/select-issue-type.js
@@ -115,13 +115,22 @@ export class SelectIssueType extends StacheElement {
                 function getParamValue(){
                     return new URL(window.location).searchParams.get("selectedIssueType") || "";
                 }
+                let timers = [];
+                function clearTimers() {
+                    timers.forEach((value) => clearTimeout(value));
+                    timers = [];
+                }
 
                 // anything happens in state, update the route 
                 // the route updates, update the state (or the route if it's wrong)
                 const resolveCurrentValue = () => {
+                    clearTimers();
+                    const curParamValue = getParamValue();
+
                     // we wait to resolve to a defined value until we can check it's right
                     if(this.issueHierarchy && this.issueHierarchy.length) {
                         const curParamValue = getParamValue();
+
                         // helps with legacy support to pick the first type
                         if(curParamValue === "Release") {
                             resolve( "Release-"+this.issueHierarchy[0].name );
@@ -139,9 +148,9 @@ export class SelectIssueType extends StacheElement {
                                 } 
                                 // set back to default
                                 else {
-                                    setTimeout( ()=> {
+                                    timers.push( setTimeout( ()=> {
                                         updateUrlParam("selectedIssueType", "", "");
-                                    },1)
+                                    },20) );
                                 }
 
                             } else {
@@ -165,6 +174,7 @@ export class SelectIssueType extends StacheElement {
                 });
 
                 listenTo(lastSet, (value)=>{
+                    console.log("LAST SET sit", value)
                     updateUrlParam("selectedIssueType", value, "");
                 });
 

--- a/public/timeline-report.js
+++ b/public/timeline-report.js
@@ -253,9 +253,20 @@ export class TimelineReport extends StacheElement {
       return this.derivedIssuesRequestData?.issuesPromise;
     },
     derivedIssues: {
+      // this can't use async b/c we need the value to turn to undefined
+      value({listenTo, resolve}){
+        const resolveValueFromPromise = () => {
+          resolve(undefined);
+          if(this.derivedIssuesRequestData?.issuesPromise) {
+            this.derivedIssuesRequestData.issuesPromise.then(resolve);
+          }
+        };
+        listenTo("derivedIssuesRequestData", resolveValueFromPromise);
+        resolveValueFromPromise();
+      }/*,
       async(resolve) {
         this.derivedIssuesRequestData?.issuesPromise.then(resolve);
-      },
+      },*/
     },
     get filteredDerivedIssues() {
       if (this.derivedIssues) {
@@ -322,12 +333,6 @@ export class TimelineReport extends StacheElement {
 
   // this all the data pre-compiled
   get rolledupAndRolledBackIssuesAndReleases() {
-    /*console.log("rolledupAndRolledBackIssuesAndReleases",{
-        filteredDerivedIssues: this.filteredDerivedIssues, 
-        rollupTimingLevelsAndCalculations: this.rollupTimingLevelsAndCalculations,
-        configuration: this.configuration
-      } )*/
-    console.log("rolledupAndRolledBackIssuesAndReleases changed!");
     if (
       !this.filteredDerivedIssues ||
       !this.rollupTimingLevelsAndCalculations ||


### PR DESCRIPTION
https://bitovi.atlassian.net/browse/TR-160

The fix is to delay removing the `selectIssueType` until the "last" of the updates from URL changes have finished running