### PR TITLE
TR-206: Usable `route-data` in Typescript

### DIFF
--- a/public/can.d.ts
+++ b/public/can.d.ts
@@ -1,31 +1,32 @@
+import { CanObservable } from "./react/hooks/useCanObservable/useCanObservable.js";
 
 type Value = {
-  from: <T>(object: ObservableObject | CanObservable<any>, keyPath?: string) => CanObservable<T>
-  bind: <T>(object: ObservableObject | CanObservable<any>, keyPath?: string) => CanObservable<T>
-}
+  from: <T>(
+    object: typeof ObservableObject | CanObservable<any>,
+    keyPath?: string
+  ) => CanObservable<T>;
+  bind: <T>(
+    object: typeof ObservableObject | CanObservable<any>,
+    keyPath?: string
+  ) => CanObservable<T>;
+};
 
 type ObservableObject = Function;
 
 class Observation<T> {
-  constructor(fn: () => T) {
-
-  }
-};
+  constructor(fn: () => T) {}
+}
 
 class SimpleObservable<T> {
-  constructor(init: T) {
-
-  }
+  constructor(init: T) {}
 
   getData: () => T;
-  value: T
+  value: T;
   on: (handler: () => void) => void;
-  off:(handler: () => void) => void;
-  set:(value: TData) => void;
+  off: (handler: () => void) => void;
+  set: (value: TData) => void;
   get(): TData;
-};
-
-
+}
 
 export var value: Value;
 export var ObservableObject: ObservableObject;

--- a/public/canjs/controls/compare-slider.js
+++ b/public/canjs/controls/compare-slider.js
@@ -1,6 +1,6 @@
 import {StacheElement} from "../../can";
 
-import routeData from "../routing/route-data.js";
+import routeData from "../routing/route-data";
 
 import {createLinearMapping, createInverseMapping} from "../../utils/math/linear-mapping";
 import {DROPDOWN_LABEL} from "../../shared/style-strings";

--- a/public/canjs/controls/select-issue-type/select-issue-type.js
+++ b/public/canjs/controls/select-issue-type/select-issue-type.js
@@ -1,6 +1,6 @@
 import { StacheElement } from "../../../can.js";
 
-import routeData from "../../routing/route-data.js";
+import routeData from "../../routing/route-data";
 import "../status-filter.js";
 
 import SimpleTooltip from "../../ui/simple-tooltip/simple-tooltip";

--- a/public/canjs/controls/select-report-type/select-report-type.js
+++ b/public/canjs/controls/select-report-type/select-report-type.js
@@ -1,7 +1,7 @@
 import { StacheElement } from "../../../can.js";
 import { DROPDOWN_LABEL } from "../../../shared/style-strings.js";
 
-import routeData from "../../routing/route-data.js";
+import routeData from "../../routing/route-data";
 
 import "../status-filter.js";
 

--- a/public/canjs/controls/select-view-settings/select-view-settings.js
+++ b/public/canjs/controls/select-view-settings/select-view-settings.js
@@ -2,7 +2,7 @@ import { StacheElement, value } from "../../../can.js";
 import { allReleasesSorted } from "../../../jira/normalized/normalize.js";
 import { DROPDOWN_LABEL } from "../../../shared/style-strings.js";
 
-import routeData from "../../routing/route-data.js";
+import routeData from "../../routing/route-data";
 import SimpleTooltip from "../../ui/simple-tooltip/simple-tooltip";
 
 import "../status-filter.js";

--- a/public/canjs/reports/gantt-grid.js
+++ b/public/canjs/reports/gantt-grid.js
@@ -41,7 +41,7 @@ const percentCompleteTooltip = stache(`
 `);
 
 import { getQuartersAndMonths } from "../../utils/date/quarters-and-months";
-import routeData from "../routing/route-data.js";
+import routeData from "../routing/route-data";
 
 // loops through and creates
 export class GanttGrid extends StacheElement {

--- a/public/canjs/routing/route-data/index.ts
+++ b/public/canjs/routing/route-data/index.ts
@@ -1,0 +1,4 @@
+import { RouteData } from "./types";
+import routeData from "./route-data";
+
+export default routeData as RouteData;

--- a/public/canjs/routing/route-data/route-data.js
+++ b/public/canjs/routing/route-data/route-data.js
@@ -1,42 +1,42 @@
-import { ObservableObject, value } from "../../can";
+import { ObservableObject, value } from "../../../can.js";
 
-import { DAY_IN_MS } from "../../utils/date/date-helpers.js";
-import { daysBetween } from "../../utils/date/days-between.js";
-import { isoToLocalDate } from "../../utils/date/local.js";
+import { DAY_IN_MS } from "../../../utils/date/date-helpers.js";
+import { daysBetween } from "../../../utils/date/days-between.js";
+import { isoToLocalDate } from "../../../utils/date/local.js";
 
 import {
   rawIssuesRequestData,
   configurationPromise,
   derivedIssuesRequestData,
   serverInfoPromise,
-} from "../controls/timeline-configuration/state-helpers.js";
+} from "../../controls/timeline-configuration/state-helpers.js";
 
 import {
   saveJSONToUrl,
   updateUrlParam,
   makeArrayOfStringsQueryParamValue,
   pushStateObservable,
-} from "./state-storage.js";
+} from "../state-storage.js";
 
-import { roundDate } from "../../utils/date/round.js";
+import { roundDate } from "../../../utils/date/round.js";
 
 const ROUND_OPTIONS = ["day", ...Object.keys(roundDate)];
 
 import {
   getAllTeamData,
   createFullyInheritedConfig,
-} from "../../react/SettingsSidebar/components/TeamConfiguration/components/Teams/services/team-configuration";
+} from "../../../react/SettingsSidebar/components/TeamConfiguration/components/Teams/services/team-configuration/team-configuration";
 
-import { createNormalizeConfiguration } from "../../react/SettingsSidebar/components/TeamConfiguration/components/Teams/shared/normalize";
+import { createNormalizeConfiguration } from "../../../react/SettingsSidebar/components/TeamConfiguration/components/Teams/shared/normalize";
 
-import { getSimplifiedIssueHierarchy } from "../../stateful-data/jira-data-requests.js";
+import { getSimplifiedIssueHierarchy } from "../../../stateful-data/jira-data-requests.js";
 import {
   issueHierarchyFromNormalizedIssues,
   makeAsyncFromObservableButStillSettableProperty,
   toSelectedParts,
-} from "./data-utils.js";
+} from "../data-utils.js";
 
-import { getTimingLevels } from "../../react/SettingsSidebar/components/TimingCalculation/helpers";
+import { getTimingLevels } from "../../../react/SettingsSidebar/components/TimingCalculation/helpers";
 
 const _15DAYS_IN_S = (DAY_IN_MS / 1000) * 15;
 

--- a/public/canjs/routing/route-data/types.ts
+++ b/public/canjs/routing/route-data/types.ts
@@ -1,0 +1,26 @@
+import { ObservableObject } from "../../../can";
+import { Jira } from "../../../jira-oidc-helpers";
+import { NormalizeIssueConfig } from "../../../jira/normalized/normalize";
+import { AppStorage } from "../../../jira/storage/common";
+import { RouteData as RouteDataClass } from "./route-data";
+
+type Overrides = {
+  showSettings: string;
+  storage: AppStorage;
+  jiraHelpers: Jira;
+  loadChildren: boolean;
+  normalizeOptions: Partial<NormalizeIssueConfig>;
+  timingCalculations: Record<string, string>;
+  childJQL: string;
+  jql: string;
+  statusesToExclude: string[];
+};
+
+type RouteDataProps = typeof RouteDataClass.props;
+
+export type RouteData = {
+  [K in Exclude<keyof RouteDataProps, keyof Overrides>]: RouteDataProps[K];
+} & {
+  assign: (obj: Partial<RouteData>) => RouteData;
+} & ObservableObject &
+  Overrides;

--- a/public/canjs/routing/utils/round.ts
+++ b/public/canjs/routing/utils/round.ts
@@ -1,7 +1,7 @@
-import routeData from "../route-data.js";
 
 import {roundDate} from "../../../utils/date/round.js";
 
+import routeData from "../route-data";
 
 export const roundDateByRoundToParam = {
     start<T extends Date | null | undefined>(date: T) : T extends Date ? Date : T {

--- a/public/react/SettingsSidebar/SettingsSidebar.tsx
+++ b/public/react/SettingsSidebar/SettingsSidebar.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 
 import { value } from "../../can";
 
-import untypedRouteData, { RouteData as RouteDataClass } from "../../canjs/routing/route-data.js";
+import routeData from "../../canjs/routing/route-data";
 
 import TeamConfiguration from "./components/TeamConfiguration";
 import ViewReports from "./components/ViewReports";
@@ -18,14 +18,6 @@ import TimingCalculation from "./components/TimingCalculation";
 import { NormalizeIssueConfig } from "../../jira/normalized/normalize";
 import Theme from "./components/Theme";
 
-type RouteDataProps = typeof RouteDataClass.props;
-
-type RouteData = {
-  [k in keyof RouteDataProps]: any;
-} & {
-  assign: (obj: Partial<RouteData>) => RouteData;
-};
-const routeData: RouteData = untypedRouteData as RouteData;
 
 export interface SettingsSidebarProps {
   isLoggedIn: boolean;

--- a/public/react/SettingsSidebar/components/IssueSource/IssueSource.tsx
+++ b/public/react/SettingsSidebar/components/IssueSource/IssueSource.tsx
@@ -11,42 +11,13 @@ import type { JiraIssue } from "../../../../jira/shared/types.js";
 import type { OidcJiraIssue } from "../../../../jira-oidc-helpers/types.js";
 import { allStatusesSorted } from "../../../../jira/normalized/normalize.js";
 
-import {
-  ObservableObject,
-  value as untypedValue,
-  Observation,
-  SimpleObservable,
-} from "../../../../can.js";
-import untypedRouteData, {
-  RouteData as RouteDataClass,
-} from "../../../../canjs/routing/route-data.js";
+import { value, Observation, SimpleObservable } from "../../../../can.js";
+import routeData from "../../../../canjs/routing/route-data";
 
 interface IssueSourceProps {
   isLoggedIn: boolean;
   jiraHelpers: Jira;
 }
-
-type Value = {
-  from: <T>(
-    object: typeof ObservableObject | CanObservable<any>,
-    keyPath?: string
-  ) => CanObservable<T>;
-  bind: <T>(
-    object: typeof ObservableObject | CanObservable<any>,
-    keyPath?: string
-  ) => CanObservable<T>;
-};
-
-const value: Value = untypedValue as unknown as Value;
-
-type RouteDataProps = typeof RouteDataClass.props;
-type RouteData = {
-  [k in keyof RouteDataProps]: any;
-} & {
-  assign: (obj: Partial<RouteData>) => RouteData;
-} & typeof ObservableObject;
-
-const routeData: RouteData = untypedRouteData as RouteData;
 
 const useRawIssuesRequestData = () => {
   const issuesPromise = useCanObservable<CanPromise<JiraIssue[] | OidcJiraIssue[]>>(

--- a/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.test.tsx
+++ b/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.test.tsx
@@ -7,7 +7,7 @@ import routeData from "../../../../canjs/routing/route-data/route-data.js";
 
 import TimingCalculation from "./TimingCalculation.js";
 
-vi.mock("../../../../../canjs/routing/route-data/route-data.js", async () => {
+vi.mock("../../../../canjs/routing/route-data/route-data.js", async () => {
   const mockRouteData = {
     simplifiedIssueHierarchy: [
       {
@@ -65,10 +65,9 @@ vi.mock("../../../../../canjs/routing/route-data/route-data.js", async () => {
     },
   };
   const { ObservableObject } = await import("../../../../can.js");
-
   return {
     default: new (ObservableObject as ObjectConstructor)(mockRouteData),
-    RouteData: (await vi.importActual("../../../../../canjs/routing/route-data/route-data.js"))
+    RouteData: (await vi.importActual("../../../../canjs/routing/route-data/route-data.js"))
       .RouteData,
   };
 });

--- a/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.test.tsx
+++ b/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 
-import routeData from "../../../../canjs/routing/route-data.js";
+import routeData from "../../../../canjs/routing/route-data/route-data.js";
 
 import TimingCalculation from "./TimingCalculation.js";
 
-vi.mock("../../../../../canjs/routing/route-data.js", async () => {
+vi.mock("../../../../../canjs/routing/route-data/route-data.js", async () => {
   const mockRouteData = {
     simplifiedIssueHierarchy: [
       {
@@ -68,7 +68,8 @@ vi.mock("../../../../../canjs/routing/route-data.js", async () => {
 
   return {
     default: new (ObservableObject as ObjectConstructor)(mockRouteData),
-    RouteData: (await vi.importActual("../../../../../canjs/routing/route-data.js")).RouteData,
+    RouteData: (await vi.importActual("../../../../../canjs/routing/route-data/route-data.js"))
+      .RouteData,
   };
 });
 

--- a/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.tsx
+++ b/public/react/SettingsSidebar/components/TimingCalculation/TimingCalculation.tsx
@@ -1,14 +1,6 @@
 import { ObservableObject, value } from "../../../../can.js";
 import React, { useMemo } from "react";
-import untypedRouteData, {
-  RouteData as RouteDataClass,
-} from "../../../../canjs/routing/route-data.js";
-
-type RouteDataProps = typeof RouteDataClass.props;
-type RouteData = {
-  [k in keyof RouteDataProps]: any;
-} & typeof ObservableObject;
-const routeData: RouteData = untypedRouteData as RouteData;
+import routeData from "../../../../canjs/routing/route-data";
 
 const selectStyle =
   "min-w-[345px] bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500";
@@ -27,7 +19,7 @@ function paddingClass(depth: number) {
 
 const TimingCalculation = () => {
   const issueHierarchy = useCanObservable(
-    value.from(routeData, "simplifiedIssueHierarchy") as unknown as CanObservable<IssueType[]>
+    value.from(routeData, "simplifiedIssueHierarchy") as CanObservable<IssueType[]>
   );
 
   const selectableTimingLevels = useMemo(() => {

--- a/public/shared/main-helper.js
+++ b/public/shared/main-helper.js
@@ -10,7 +10,7 @@ import { getConnectRequestHelper } from "../request-helpers/connect-request-help
 
 import { directlyReplaceUrlParam } from "../canjs/routing/state-storage.js";
 import { route, value } from "../can.js";
-import routeData from "../canjs/routing/route-data.js";
+import routeData from "../canjs/routing/route-data";
 
 export default async function mainHelper(
   config,

--- a/public/timeline-report.js
+++ b/public/timeline-report.js
@@ -1,6 +1,6 @@
 import { StacheElement, type, queues } from "./can.js";
 
-import routeData from "./canjs/routing/route-data.js";
+import routeData from "./canjs/routing/route-data";
 
 import "./canjs/controls/status-filter.js";
 import "./canjs/controls/compare-slider.js";


### PR DESCRIPTION
Define the route-data types in its own `types.ts` and define a barrel file to cast the exported variable