### PR TITLE
fixes status filters for TR-243

### DIFF
--- a/public/canjs/controls/select-view-settings/select-view-settings.js
+++ b/public/canjs/controls/select-view-settings/select-view-settings.js
@@ -102,7 +102,7 @@ class SelectViewSettingsDropdown extends StacheElement {
                     <label>Show only {{this.firstIssueTypeWithStatuses}} statuses:</label>
                 
                     <status-filter 
-                        statuses:from="this.statuses"
+                        statuses:from="this.routeData.allStatusesSorted"
                         param:raw="statusesToShow"
                         selectedStatuses:bind="this.routeData.statusesToShow"
                         inputPlaceholder:raw="Search for statuses"
@@ -112,7 +112,7 @@ class SelectViewSettingsDropdown extends StacheElement {
                     <label>Hide {{this.firstIssueTypeWithStatuses}} statuses:</label>
 
                     <status-filter 
-                        statuses:from="this.statuses" 
+                        statuses:from="this.routeData.allStatusesSorted" 
                         param:raw="statusesToRemove"
                         selectedStatuses:bind="this.routeData.statusesToRemove"
                         inputPlaceholder:raw="Search for statuses"
@@ -209,7 +209,7 @@ class SelectViewSettingsDropdown extends StacheElement {
             <div class="flex gap-2 mt-1">
                 <label>{{this.firstIssueTypeWithStatuses}} statuses to show as planning:</label>
                 <status-filter 
-                    statuses:from="this.statuses" 
+                    statuses:from="this.routeData.allStatusesSorted" 
                     param:raw="planningStatuses"
                     selectedStatuses:bind="this.routeData.planningStatuses"
                     inputPlaceholder:raw="Search for statuses"
@@ -281,9 +281,6 @@ export class SelectViewSettings extends StacheElement {
         let dropdown = new SelectViewSettingsDropdown().bindings({
             canGroup: value.from(this,"canGroup"),
             firstIssueTypeWithStatuses: value.from(this,"firstIssueTypeWithStatuses"),
-
-            // this could probably be calculated by itself
-            statuses: value.from(this,"statuses"),
             releases: value.from(this,"releases")
             // onSelection: this.onSelection.bind(this)
         })

--- a/public/canjs/routing/route-data/route-data.js
+++ b/public/canjs/routing/route-data/route-data.js
@@ -4,6 +4,8 @@ import { DAY_IN_MS } from "../../../utils/date/date-helpers.js";
 import { daysBetween } from "../../../utils/date/days-between.js";
 import { isoToLocalDate } from "../../../utils/date/local.js";
 
+import { allStatusesSorted } from "../../../jira/normalized/normalize.ts";
+
 import {
   rawIssuesRequestData,
   configurationPromise,
@@ -268,6 +270,13 @@ export class RouteData extends ObservableObject {
         listenTo("derivedIssuesRequestData", resolveValueFromPromise);
         resolveValueFromPromise();
       },
+    },
+    get allStatusesSorted(){
+      if (this.derivedIssues) {
+        return allStatusesSorted(this.derivedIssues);
+      } else {
+        return [];
+      }
     },
     timingCalculations: {
       value({ resolve, lastSet, listenTo }) {

--- a/public/canjs/ui/autocomplete/autocomplete.js
+++ b/public/canjs/ui/autocomplete/autocomplete.js
@@ -3,9 +3,7 @@ import SimpleTooltip from "../simple-tooltip/simple-tooltip.js";
 
 // create global tooltip reference
 
-const TOOLTIP = new SimpleTooltip();
 
-document.body.append(TOOLTIP);
 
 class AutoCompleteSuggestions extends StacheElement {
     static view = `
@@ -58,7 +56,11 @@ class AutoComplete extends StacheElement {
         const matches = this.data.filter( item => {
             return item.toLowerCase().includes(searchTerm.toLowerCase()) && !this.selected.includes(item)
         })
-        this.showingSuggestions = true;
+        const TOOLTIP = new SimpleTooltip();
+
+        document.body.append(TOOLTIP);
+        TOOLTIP.showingSuggestions = true;
+        this.TOOLTIP = TOOLTIP;
         // this could be made more efficient, but is probably ok
         TOOLTIP.belowElementInScrollingContainer(this, 
             new AutoCompleteSuggestions().initialize({
@@ -72,7 +74,7 @@ class AutoComplete extends StacheElement {
         // handle when someone clicks off the element
         this.listenTo(window, "click", (event)=>{
             // if we aren't showing, don't worry about it
-            if(!this.showingSuggestions) {
+            if(!this?.TOOLTIP?.showingSuggestions) {
                 return;
             }
             // do nothing if the input was clicked on
@@ -80,15 +82,18 @@ class AutoComplete extends StacheElement {
                 return
             }
             // do nothing if the TOOLTIP was clicked
-            if(TOOLTIP.contains(event.target)) {
+            if(this.TOOLTIP && this.TOOLTIP.contains(event.target)) {
                 return;
             }
             this.stopShowingSuggestions()
         })
     }
     stopShowingSuggestions(){
-        TOOLTIP.leftElement();
-        this.showingSuggestions = false;
+        this.TOOLTIP.leftElement();
+        this.TOOLTIP.showingSuggestions = false;
+    }
+    disconnected(){
+        this.TOOLTIP && document.body.removeChild(this.TOOLTIP);
     }
 }
 

--- a/public/canjs/ui/simple-tooltip/simple-tooltip.js
+++ b/public/canjs/ui/simple-tooltip/simple-tooltip.js
@@ -124,10 +124,15 @@ class SimpleTooltip extends HTMLElement {
     }
     
     let leftFromContainer = elementRect.left - containerRect.left;
+    // if the element would go past the page to the right
     if(elementRect.left  + tooltipRect.width > window.innerWidth) {
-      leftFromContainer = elementRect.right - containerRect.left - tooltipRect.width;
+      //leftFromContainer = elementRect.right - containerRect.left - tooltipRect.width;
+      this.style.right = (containerRect.right - elementRect.right) + "px";
+      this.style.left = "";
+    } else {
+      this.style.left = leftFromContainer +"px";
     }
-    this.style.left = leftFromContainer +"px";
+    
   }
   rightOfElementInScrollingContainer(element, DOM) {
     // find if there's a scrolling container and move ourselves to that 

--- a/public/react/SettingsSidebar/components/IssueSource/components/LoadChildren/LoadChildren.test.tsx
+++ b/public/react/SettingsSidebar/components/IssueSource/components/LoadChildren/LoadChildren.test.tsx
@@ -16,9 +16,6 @@ describe("<LoadChildren />", () => {
       />
     );
 
-    const accordionTitle = screen.getByText(/load children/i);
-    expect(accordionTitle).toBeInTheDocument();
-
     const loadChildrenCheckbox = screen.getByLabelText(
       /load all children of jql specified issues/i
     );

--- a/public/react/SettingsSidebar/components/IssueSource/components/LoadChildren/LoadChildren.tsx
+++ b/public/react/SettingsSidebar/components/IssueSource/components/LoadChildren/LoadChildren.tsx
@@ -26,12 +26,6 @@ const LoadChildren: FC<LoadChildrenProps> = ({
 
   return (
     <div>
-      <Hr />
-      <Accordion startsOpen>
-        <AccordionTitle>
-          <p className="font-semibold">Load children</p>
-        </AccordionTitle>
-        <AccordionContent>
           <div className="flex flex-col gap-3 py-4">
             <div className="flex gap-1 items-center">
               <Checkbox
@@ -56,8 +50,6 @@ const LoadChildren: FC<LoadChildrenProps> = ({
               </div>
             )}
           </div>
-        </AccordionContent>
-      </Accordion>
       <Hr />
     </div>
   );

--- a/public/timeline-report.js
+++ b/public/timeline-report.js
@@ -35,7 +35,7 @@ export class TimelineReport extends StacheElement {
           class="border-gray-100 border-r border-neutral-301 relative block bg-white shrink-0" 
         ></div>
     {{/if}}
-    <div class="fullish-vh pl-4 pr-4 flex flex-1 flex-col overflow-y-auto relative" on:click="this.goBack()">
+    <div class="fullish-vh pl-4 pr-4 flex flex-1 flex-col overflow-y-auto relative">
 
       <div id='sample-data-notice' class='pt-4'></div>
 
@@ -53,9 +53,7 @@ export class TimelineReport extends StacheElement {
 
         <select-view-settings
           jiraHelpers:from="this.jiraHelpers"
-          
           releasesToShow:to="this.releasesToShow"
-          statuses:from="this.statuses"
           derivedIssues:from="this.routeData.derivedIssues"
           ></select-view-settings>
       </div>


### PR DESCRIPTION
A few bugs:

- `goBack` didn't exist and was trying to be called
- The status filters were not working
- I removed the accordion that was just hiding another callback